### PR TITLE
Add functionality to convert a JSON to a string

### DIFF
--- a/doc/jdaddy.txt
+++ b/doc/jdaddy.txt
@@ -31,6 +31,10 @@ gqaj                    Replace the outermost JSON with a pretty printed
 ["x]gwaj                Merge the JSON from the register into the outermost
                         JSON.
 
+                                                *gsj*
+gsj                     Convert the JSON into a string. 
+
+
 Pretty printing indents based on 'shiftwidth' and wraps at 'textwidth'.
 
  vim:tw=78:et:ft=help:norl:

--- a/plugin/jdaddy.vim
+++ b/plugin/jdaddy.vim
@@ -16,4 +16,6 @@ nnoremap <silent> gqaj :exe jdaddy#reformat('jdaddy#outer_pos', v:count1)<CR>
 nnoremap <silent> gwij :exe jdaddy#reformat('jdaddy#inner_pos', v:count1, v:register)<CR>
 nnoremap <silent> gwaj :exe jdaddy#reformat('jdaddy#outer_pos', v:count1, v:register)<CR>
 
+nnoremap <silent> gsj :exe jdaddy#stringify('jdaddy#outer_pos', v:count1)<CR>
+
 " vim:set et sw=2:


### PR DESCRIPTION
I have installed this plugin today because I was looking for a fast way to pretty print JSON and this almost fulfilled my needs. But I also wanted a functionality to stringify the JSON, so taking as start some of your defined functionalities I developed the functionality I needed.
I just leave this PR in case you find it useful to share for the plugin users. In case you like it, let me know any corrections you might want of it.